### PR TITLE
[Seed] Add automated database seeding and constants

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,8 @@
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slider": "^1.3.6",
         "@radix-ui/react-slot": "^1.2.3",
+        "@types/bcrypt": "^6.0.0",
+        "bcrypt": "^6.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.544.0",
@@ -27,6 +29,7 @@
         "react-use": "^17.6.0",
         "tailwind-merge": "^3.3.1",
         "tailwindcss-animate": "^1.0.7",
+        "ts-node": "^10.9.2",
         "uploadthing": "^7.7.4",
         "vaul": "^1.1.2",
         "zustand": "^5.0.11"
@@ -103,6 +106,28 @@
       "integrity": "sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ==",
       "devOptional": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "node_modules/@effect/platform": {
       "version": "0.90.3",
@@ -893,7 +918,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -2385,6 +2409,30 @@
         "tailwindcss": "4.1.13"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -2394,6 +2442,15 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-/oJGukuH3D2+D+3H4JWLaAsJ/ji86dhRidzZ/Od7H/i8g+aCmvkeCc6Ni/f9uxGLSQVCRZkX2/lqEFG2BvWtlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/estree": {
@@ -2427,7 +2484,6 @@
       "version": "20.19.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.17.tgz",
       "integrity": "sha512-gfehUI8N1z92kygssiuWvLiwcbOB3IRktR6hTDgJlXMYh5OvkPSRmgfoBUmfZt+vhwJtX7v1Yw4KvvAf7c5QKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -3037,7 +3093,6 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -3054,6 +3109,18 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/ajv": {
@@ -3088,6 +3155,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -3347,6 +3420,20 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -3629,6 +3716,12 @@
         "toggle-selection": "^1.0.6"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3843,6 +3936,15 @@
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/doctrine": {
       "version": "2.1.0",
@@ -6098,6 +6200,12 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "license": "ISC"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -6403,12 +6511,32 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.6.0.tgz",
+      "integrity": "sha512-gBVjCaqDlRUk0EwoPNKzIr9KkS9041G/q31IBShPs1Xz6UTA+EXdZADbzqAJQrpDRq71CIMnOP5VMut3SL0z5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
     "node_modules/node-fetch-native": {
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
       "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
     },
     "node_modules/node-gyp-build-optional-packages": {
       "version": "5.2.2",
@@ -8143,6 +8271,49 @@
       "integrity": "sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ==",
       "license": "Unlicense"
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -8267,7 +8438,6 @@
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -8300,7 +8470,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -8428,6 +8597,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "license": "MIT"
     },
     "node_modules/valibot": {
       "version": "1.2.0",
@@ -8589,6 +8764,15 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,11 @@
     "start": "next start",
     "lint": "eslint",
     "prisma:push": "prisma db push",
-    "prisma:studio": "prisma studio"
+    "prisma:studio": "prisma studio",
+    "prisma:seed": "prisma db seed"
+  },
+  "prisma": {
+    "seed": "ts-node --compiler-options {\"module\":\"CommonJS\"} prisma/seed.ts"
   },
   "dependencies": {
     "@prisma/adapter-pg": "^7.4.2",
@@ -19,6 +23,8 @@
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slider": "^1.3.6",
     "@radix-ui/react-slot": "^1.2.3",
+    "@types/bcrypt": "^6.0.0",
+    "bcrypt": "^6.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.544.0",
@@ -30,6 +36,7 @@
     "react-use": "^17.6.0",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
+    "ts-node": "^10.9.2",
     "uploadthing": "^7.7.4",
     "vaul": "^1.1.2",
     "zustand": "^5.0.11"

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -6,4 +6,7 @@ export default defineConfig({
     datasource: {
         url: env('DATABASE_URL'),
     },
+    migrations: {
+        seed: 'npx tsx ./prisma/seed.ts',
+    }
 });

--- a/prisma/constants.ts
+++ b/prisma/constants.ts
@@ -1,0 +1,215 @@
+export const categories = [
+    {
+        name: 'Пиццы',
+    },
+    {
+        name: 'Завтрак',
+    },
+    {
+        name: 'Закуски',
+    },
+    {
+        name: 'Коктейли',
+    },
+    {
+        name: 'Напитки',
+    },
+]
+
+export const ingredients = [
+    {
+        name: 'Сырный бортик',
+        price: 179,
+        imageUrl:
+            'https://cdn.dodostatic.net/static/Img/Ingredients/99f5cb91225b4875bd06a26d2e842106.png',
+    },
+    {
+        name: 'Сливочная моцарелла',
+        price: 79,
+        imageUrl:
+            'https://cdn.dodostatic.net/static/Img/Ingredients/cdea869ef287426386ed634e6099a5ba.png',
+    },
+    {
+        name: 'Сыры чеддер и пармезан',
+        price: 79,
+        imageUrl: 'https://cdn.dodostatic.net/static/Img/Ingredients/000D3A22FA54A81411E9AFA69C1FE796',
+    },
+    {
+        name: 'Острый перец халапеньо',
+        price: 59,
+        imageUrl:
+            'https://cdn.dodostatic.net/static/Img/Ingredients/11ee95b6bfdf98fb88a113db92d7b3df.png',
+    },
+    {
+        name: 'Нежный цыпленок',
+        price: 79,
+        imageUrl: 'https://cdn.dodostatic.net/static/Img/Ingredients/000D3A39D824A82E11E9AFA5B328D35A',
+    },
+    {
+        name: 'Шампиньоны',
+        price: 59,
+        imageUrl: 'https://cdn.dodostatic.net/static/Img/Ingredients/000D3A22FA54A81411E9AFA67259A324',
+    },
+    {
+        name: 'Ветчина',
+        price: 79,
+        imageUrl: 'https://cdn.dodostatic.net/static/Img/Ingredients/000D3A39D824A82E11E9AFA61B9A8D61',
+    },
+    {
+        name: 'Пикантная пепперони',
+        price: 79,
+        imageUrl: 'https://cdn.dodostatic.net/static/Img/Ingredients/000D3A22FA54A81411E9AFA6258199C3',
+    },
+    {
+        name: 'Острая чоризо',
+        price: 79,
+        imageUrl: 'https://cdn.dodostatic.net/static/Img/Ingredients/000D3A22FA54A81411E9AFA62D5D6027',
+    },
+    {
+        name: 'Маринованные огурчики',
+        price: 59,
+        imageUrl: 'https://cdn.dodostatic.net/static/Img/Ingredients/000D3A21DA51A81211E9EA89958D782B',
+    },
+    {
+        name: 'Свежие томаты',
+        price: 59,
+        imageUrl: 'https://cdn.dodostatic.net/static/Img/Ingredients/000D3A39D824A82E11E9AFA7AC1A1D67',
+    },
+    {
+        name: 'Красный лук',
+        price: 59,
+        imageUrl: 'https://cdn.dodostatic.net/static/Img/Ingredients/000D3A22FA54A81411E9AFA60AE6464C',
+    },
+    {
+        name: 'Сочные ананасы',
+        price: 59,
+        imageUrl: 'https://cdn.dodostatic.net/static/Img/Ingredients/000D3A21DA51A81211E9AFA6795BA2A0',
+    },
+    {
+        name: 'Итальянские травы',
+        price: 39,
+        imageUrl:
+            'https://cdn.dodostatic.net/static/Img/Ingredients/370dac9ed21e4bffaf9bc2618d258734.png',
+    },
+    {
+        name: 'Сладкий перец',
+        price: 59,
+        imageUrl: 'https://cdn.dodostatic.net/static/Img/Ingredients/000D3A22FA54A81411E9AFA63F774C1B',
+    },
+    {
+        name: 'Кубики брынзы',
+        price: 79,
+        imageUrl: 'https://cdn.dodostatic.net/static/Img/Ingredients/000D3A39D824A82E11E9AFA6B0FFC349',
+    },
+    {
+        name: 'Митболы',
+        price: 79,
+        imageUrl:
+            'https://cdn.dodostatic.net/static/Img/Ingredients/b2f3a5d5afe44516a93cfc0d2ee60088.png',
+    },
+].map((obj, index) => ({ id: index + 1, ...obj }));
+
+export const products = [
+    {
+        name: 'Омлет с ветчиной и грибами',
+        imageUrl:
+            'https://media.dodostatic.net/image/r:292x292/11EE7970321044479C1D1085457A36EB.webp',
+        categoryId: 2,
+    },
+    {
+        name: 'Омлет с пепперони',
+        imageUrl:
+            'https://media.dodostatic.net/image/r:292x292/11EE94ECF33B0C46BA410DEC1B1DD6F8.webp',
+        categoryId: 2,
+    },
+    {
+        name: 'Кофе Латте',
+        imageUrl:
+            'https://media.dodostatic.net/image/r:292x292/11EE7D61B0C26A3F85D97A78FEEE00AD.webp',
+        categoryId: 2,
+    },
+    {
+        name: 'Дэнвич ветчина и сыр',
+        imageUrl:
+            'https://media.dodostatic.net/image/r:292x292/11EE796FF0059B799A17F57A9E64C725.webp',
+        categoryId: 3,
+    },
+    {
+        name: 'Куриные наггетсы',
+        imageUrl:
+            'https://media.dodostatic.net/image/r:292x292/11EE7D618B5C7EC29350069AE9532C6E.webp',
+        categoryId: 3,
+    },
+    {
+        name: 'Картофель из печи с соусом 🌱',
+        imageUrl:
+            'https://media.dodostatic.net/image/r:292x292/11EED646A9CD324C962C6BEA78124F19.webp',
+        categoryId: 3,
+    },
+    {
+        name: 'Додстер',
+        imageUrl:
+            'https://media.dodostatic.net/image/r:292x292/11EE796F96D11392A2F6DD73599921B9.webp',
+        categoryId: 3,
+    },
+    {
+        name: 'Острый Додстер 🌶️🌶️',
+        imageUrl:
+            'https://media.dodostatic.net/image/r:292x292/11EE796FD3B594068F7A752DF8161D04.webp',
+        categoryId: 3,
+    },
+    {
+        name: 'Банановый молочный коктейль',
+        imageUrl:
+            'https://media.dodostatic.net/image/r:292x292/11EEE20B8772A72A9B60CFB20012C185.webp',
+        categoryId: 4,
+    },
+    {
+        name: 'Карамельное яблоко молочный коктейль',
+        imageUrl:
+            'https://media.dodostatic.net/image/r:292x292/11EE79702E2A22E693D96133906FB1B8.webp',
+        categoryId: 4,
+    },
+    {
+        name: 'Молочный коктейль с печеньем Орео',
+        imageUrl:
+            'https://media.dodostatic.net/image/r:292x292/11EE796FA1F50F8F8111A399E4C1A1E3.webp',
+        categoryId: 4,
+    },
+    {
+        name: 'Классический молочный коктейль 👶',
+        imageUrl:
+            'https://media.dodostatic.net/image/r:292x292/11EE796F93FB126693F96CB1D3E403FB.webp',
+        categoryId: 4,
+    },
+    {
+        name: 'Ирландский Капучино',
+        imageUrl:
+            'https://media.dodostatic.net/image/r:292x292/11EE7D61999EBDA59C10E216430A6093.webp',
+        categoryId: 5,
+    },
+    {
+        name: 'Кофе Карамельный капучино',
+        imageUrl:
+            'https://media.dodostatic.net/image/r:292x292/11EE7D61AED6B6D4BFDAD4E58D76CF56.webp',
+        categoryId: 5,
+    },
+    {
+        name: 'Кофе Кокосовый латте',
+        imageUrl:
+            'https://media.dodostatic.net/image/r:292x292/11EE7D61B19FA07090EE88B0ED347F42.webp',
+        categoryId: 5,
+    },
+    {
+        name: 'Кофе Американо',
+        imageUrl:
+            'https://media.dodostatic.net/image/r:292x292/11EE7D61B044583596548A59078BBD33.webp',
+        categoryId: 5,
+    },
+    {
+        name: 'Кофе Латте',
+        imageUrl:
+            'https://media.dodostatic.net/image/r:292x292/11EE7D61B0C26A3F85D97A78FEEE00AD.webp',
+        categoryId: 5,
+    },
+]

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -103,8 +103,8 @@ model CartItem {
   productItem   ProductItem @relation(fields: [productItemId], references: [id])
   productItemId Int
 
-  cart   Cart @relation(fields: [cardId], references: [id])
-  cardId Int
+  cart   Cart @relation(fields: [cartId], references: [id])
+  cartId Int
 
   quantity Int
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,6 +13,7 @@ model User {
   fullName String
   password String
   role     UserRole @default(USER)
+  verified DateTime
 
   provider   String?
   providerId String?
@@ -40,7 +41,7 @@ model Product {
   name     String
   imageUrl String
 
-  ingredients Intgredient[]
+  ingredients Ingredient[]
   items       ProductItem[]
 
   category   Category @relation(fields: [categoryId], references: [id])
@@ -66,7 +67,7 @@ model ProductItem {
   updatedAt DateTime @updatedAt
 }
 
-model Intgredient {
+model Ingredient {
   id Int @id @default(autoincrement())
 
   name     String
@@ -107,7 +108,7 @@ model CartItem {
 
   quantity Int
 
-  ingredients Intgredient[]
+  ingredients Ingredient[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,107 @@
+
+import {hashSync} from 'bcrypt'
+import {categories, ingredients, products} from "@/prisma/constants";
+import {prisma} from "@/prisma/prisma-client";
+
+async function up() {
+    await prisma.user.createMany({
+        data: [
+            {
+                fullName: 'User Test',
+                email: 'user@test.ru',
+                password: hashSync('111111', 10),
+                verified: new Date(),
+                role: 'USER',
+            },
+            {
+                fullName: 'Admin Admin',
+                email: 'admin@test.ru',
+                password: hashSync('111111', 10),
+                verified: new Date(),
+                role: 'ADMIN',
+            },
+        ],
+    })
+
+    await prisma.category.createMany({
+        data: categories
+    });
+
+    await prisma.ingredient.createMany({
+        data: ingredients
+    })
+
+    await prisma.product.createMany({
+        data: products
+    });
+
+    const pizza1 = await prisma.product.create({
+        data: {
+            name: 'Пепперони фреш',
+            imageUrl:
+                'https://media.dodostatic.net/image/r:233x233/11EE7D61304FAF5A98A6958F2BB2D260.webp',
+            categoryId: 1,
+            ingredients: {
+                connect: ingredients.slice(0, 5),
+            },
+        },
+    });
+
+    const pizza2 = await prisma.product.create({
+        data: {
+            name: 'Сырная',
+            imageUrl:
+                'https://media.dodostatic.net/image/r:233x233/11EE7D610CF7E265B7C72BE5AE757CA7.webp',
+            categoryId: 1,
+            ingredients: {
+                connect: ingredients.slice(5, 10),
+            },
+        },
+    });
+
+    const pizza3 = await prisma.product.create({
+        data: {
+            name: 'Чоризо фреш',
+            imageUrl:
+                'https://media.dodostatic.net/image/r:584x584/11EE7D61706D472F9A5D71EB94149304.webp',
+            categoryId: 1,
+            ingredients: {
+                connect: ingredients.slice(10, 40),
+            },
+        },
+    });
+}
+
+async function down() {
+    const tables = [
+        'User',
+        'Product',
+        'Ingredient',
+        'Category',
+    ];
+
+    for (const table of tables) {
+        await prisma.$executeRawUnsafe(
+            `TRUNCATE TABLE "${table}" RESTART IDENTITY CASCADE;`
+        );
+    }
+}
+
+async function main() {
+    try {
+        await down();
+        await up();
+    } catch (e) {
+        console.error(e)
+    }
+}
+
+main()
+    .then(async () => {
+        await prisma.$disconnect();
+    })
+    .catch(async (e) => {
+        console.error(e);
+        await prisma.$disconnect();
+        process.exit(1);
+    });

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,6 +1,6 @@
-
 import {hashSync} from 'bcrypt'
 import {categories, ingredients, products} from "@/prisma/constants";
+import {Prisma} from "@prisma/client";
 import {prisma} from "@/prisma/prisma-client";
 
 async function up() {
@@ -70,6 +70,51 @@ async function up() {
             },
         },
     });
+
+    const price = () => Math.floor(Math.random() * (600 - 190) + 190);
+
+    const pizzaConfigs = [
+        {id: pizza1.id, variants: [[1, 20], [2, 30], [2, 40]]},
+        {id: pizza2.id, variants: [[1, 20], [1, 30], [1, 40], [2, 20], [2, 30], [2, 40]]},
+        {id: pizza3.id, variants: [[1, 20], [2, 30], [2, 40]]},
+    ];
+
+    const data: Prisma.ProductItemUncheckedCreateInput[] = [
+        ...pizzaConfigs.flatMap(({id, variants}) =>
+            variants.map(([pizzaType, size]) => ({productId: id, pizzaType, size, price: price()}))
+        ),
+
+        ...Array.from({length: 17}, (_, i) => ({productId: i + 1, price: price()}))
+    ];
+
+    await prisma.productItem.createMany({data});
+
+    await prisma.cart.createMany({
+        data: [
+            {
+                userId: 1,
+                totalAmount: 0,
+                token: '11111',
+            },
+            {
+                userId: 2,
+                totalAmount: 0,
+                token: '22222',
+            }
+        ]
+    });
+
+    await prisma.cartItem.create({
+        data:
+            {
+                productItemId: 1,
+                cartId: 1,
+                quantity: 2,
+                ingredients: {
+                    connect: [{id: 1}, {id: 2}, {id: 3}, {id: 4}]
+                }
+            }
+    })
 }
 
 async function down() {
@@ -78,6 +123,9 @@ async function down() {
         'Product',
         'Ingredient',
         'Category',
+        'ProductItem',
+        'Cart',
+        'CartItem'
     ];
 
     for (const table of tables) {


### PR DESCRIPTION
Description
Added a script to automatically populate the database with initial e-commerce data.

Key changes
- Created `prisma/seed.ts` to manage the seeding process.
- Added `prisma/constants.ts` with categories, ingredients, and products.
- Implemented logic to generate `ProductItem` variations for different sizes and types.
- Configured `ts-node` and added the `prisma:seed` command to `package.json`.

Closes #7 