### PR TITLE
[Products] Display products and categories from database

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,7 +20,7 @@ export default async function Home() {
 
             </Container>
 
-            <TopBar/>
+            <TopBar categories={categories.filter((category) => category.products.length > 0)}/>
 
             <Container className="mt-10 pb-14">
                 <div className="flex gap-[80px]">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,18 @@
 import {Container, Title, TopBar, Filters, ProductsGroupList} from "@/components/shared";
+import {prisma} from "@/prisma/prisma-client";
 
-export default function Home() {
+export default async function Home() {
+    const categories = await prisma.category.findMany({
+        include: {
+            products: {
+                include: {
+                    items: true,
+                    ingredients: true
+                }
+            },
+        }
+    })
+
     return (
         <>
             <Container className="mt-10">
@@ -21,61 +33,18 @@ export default function Home() {
                     {/* Список товаров */}
                     <div className="flex-1">
                         <div className="flex flex-col gap-16">
-                            <ProductsGroupList
-                                title="Пиццы"
-                                categoryId={1}
-                                items={[
-                                    {
-                                        id: 1,
-                                        name: "Мега Ранч",
-                                        imageUrl: "https://media.dodostatic.net/image/r:584x584/019ac618b24778eba506f9bebdae5546.avif",
-                                        price: 14.90,
-                                        items: [{ price: 14.90 }, { price: 26.90 }, { price: 31.90 }]
-                                    },
-                                    {
-                                        id: 2,
-                                        name: "Мега Сырный цыпленок",
-                                        imageUrl: "https://media.dodostatic.net/image/r:584x584/019ac61af813785bb3dd96307ff6ef4a.avif",
-                                        price: 16.90,
-                                        items: [{ price: 16.90 }, { price: 26.90 }, { price: 31.90 }]
-                                    },
-                                    {
-                                        id: 3,
-                                        name: "Мега Барбекю",
-                                        imageUrl: "https://media.dodostatic.net/image/r:584x584/019b21757d4b7440809316ed7be8844b.avif",
-                                        price: 16.90,
-                                        items: [{ price: 16.90 }, { price: 26.90 }, { price: 31.90 }]
-                                    }
-                                ]}
-                            />
-
-                            <ProductsGroupList
-                                title="Комбо"
-                                categoryId={2}
-                                items={[
-                                    {
-                                        id: 1,
-                                        name: "Комбо Масала",
-                                        imageUrl: "https://media.dodostatic.net/image/r:584x584/019c65cfa535733fac44479e9720eb66.avif",
-                                        price: 36.99,
-                                        items: [{ price: 36.99 }]
-                                    },
-                                    {
-                                        id: 2,
-                                        name: "2 Сытные пиццы 30 см и напиток",
-                                        imageUrl: "https://media.dodostatic.net/image/r:584x584/019c41632a84762ea56eda397372f466.avif",
-                                        price: 42.99,
-                                        items: [{ price: 42.99 }]
-                                    },
-                                    {
-                                        id: 3,
-                                        name: "2 Сытные пиццы 30 см и 2 напитка",
-                                        imageUrl: "https://media.dodostatic.net/image/r:584x584/019c41640e73748c82268f3d0d4299d3.avif",
-                                        price: 45.99,
-                                        items: [{ price: 45.99 }]
-                                    }
-                                ]}
-                            />
+                            {
+                                categories.map((category) => (
+                                    category.products.length > 0 && (
+                                        <ProductsGroupList
+                                            key={category.id}
+                                            title={category.name}
+                                            categoryId={category.id}
+                                            items={category.products}
+                                        />
+                                    )
+                                ))
+                            }
                         </div>
                     </div>
 

--- a/components/shared/categories.tsx
+++ b/components/shared/categories.tsx
@@ -3,37 +3,30 @@
 import React from 'react';
 import {cn} from "@/lib/utils";
 import {useCategoryStore} from "@/store/category";
+import {Category} from "@prisma/client";
 
 interface Props {
+    items: Category[];
     className?: string;
 }
 
-const cats = [
-    {id: 1, name: 'Пиццы'},
-    {id: 2, name: 'Комбо'},
-    {id: 3, name: 'Закуски'},
-    {id: 4, name: 'Коктейли'},
-    {id: 5, name: 'Кофе'},
-    {id: 6, name: 'Напитки'},
-    {id: 7, name: 'Десерты'}
-];
-
-export const Categories: React.FC<Props> = ({className}) => {
+export const Categories: React.FC<Props> = ({items, className}) => {
     const categoryActiveId = useCategoryStore((state) => state.activeId);
     return (
         <div className={cn('inline-flex gap-1 bg-gray-50 p-1 rounded-2xl', className)}>
             {
-                cats.map((cat, index) => (
+                items.map((cat, index) => (
                     <a
                         className={cn(
-                            'flex items-center font-bold h-11 rounded-2xl px-5',
+                            'flex items-center font-bold h-11 rounded-2xl px-5 cursor-pointer',
                             categoryActiveId === cat.id && 'bg-white shadow-md shadow-gray-200 text-primary'
                         )}
-                        href={`/#${cat.name}`}
+                        onClick={(e) => {
+                            e.preventDefault();
+                            document.getElementById(cat.name)?.scrollIntoView({behavior: 'smooth', block: 'start'});
+                        }}
                         key={index}>
-                        <button>
-                            {cat.name}
-                        </button>
+                        {cat.name}
                     </a>
                 ))
             }

--- a/components/shared/products-group-list.tsx
+++ b/components/shared/products-group-list.tsx
@@ -10,7 +10,7 @@ import {useCategoryStore} from "@/store/category";
 interface Props {
     title: string;
     items: any[];
-    listClassName: string;
+    listClassName?: string;
     categoryId: number;
     className?: string;
 }

--- a/components/shared/top-bar.tsx
+++ b/components/shared/top-bar.tsx
@@ -3,17 +3,19 @@ import {cn} from "@/lib/utils";
 import {Categories} from "@/components/shared/categories";
 import {SortPopup} from "@/components/shared/sort-popup";
 import {Container} from "@/components/shared/container";
+import {Category} from "@prisma/client";
 
 interface Props {
+    categories: Category[];
     className?: string;
 }
 
-export const TopBar: React.FC<Props> = ({className}) => {
+export const TopBar: React.FC<Props> = ({categories, className}) => {
     return (
         <div
             className={cn('sticky top-0 bg-white py-5 shadow-lg shadow-black/5 z-10', className)}>
             <Container className="flex items-center justify-between ">
-                <Categories/>
+                <Categories items={categories}/>
                 <SortPopup/>
             </Container>
         </div>


### PR DESCRIPTION
Description
Replaces hardcoded product data with real database queries using Prisma, wiring up categories and products dynamically across the main page and navigation.

Key changes
- Fetched categories with nested products and ingredients in `app/page.tsx` using Prisma
- Replaced static product lists with a dynamic map over DB categories
- Updated `TopBar` to accept and forward `categories` prop
- Refactored `Categories` component to render dynamic items from DB
- Replaced anchor-based navigation with smooth scroll via `scrollIntoView`
- Made `listClassName` prop optional in `ProductsGroupList`

Closes #15